### PR TITLE
Fix #4 by considering ExternalModuleDependencies

### DIFF
--- a/src/PSPublishHelper/private/Get-NuspecContents.ps1
+++ b/src/PSPublishHelper/private/Get-NuspecContents.ps1
@@ -14,7 +14,7 @@ function Get-NuspecContents {
 
         $TagsText = Resolve-PSModuleTags -Module $Module -Tags $PSData.Tags
 
-        $RequireLicenseAcceptanceText = ([bool]$PSData.RequireLicenseAcceptance).ToString().ToLower() 
+        $RequireLicenseAcceptanceText = ([bool]$PSData.RequireLicenseAcceptance).ToString().ToLower()
 
         $Description = $Module.Description
         if ([string]::IsNullOrWhiteSpace($Description)) {
@@ -52,7 +52,7 @@ function Get-NuspecContents {
         $ArgumentList.Add($IconUriText)
 
         $DependencyText = @(
-            $Module | Resolve-PSModuleDependency | Format-PSModuleDependency
+            $Module | Resolve-PSModuleDependency -ExternalModuleDependencies $PSData.ExternalModuleDependencies | Format-PSModuleDependency
         ) -Join ([Environment]::NewLine)
         $ArgumentList.Add($DependencyText)
 

--- a/src/PSPublishHelper/private/Resolve-PSData.ps1
+++ b/src/PSPublishHelper/private/Resolve-PSData.ps1
@@ -30,6 +30,7 @@ function Resolve-PSData {
             ProjectUri = $ProjectUri
             Prerelease = $null
             RequireLicenseAcceptance = $null
+            ExternalModuleDependencies = @()
         }
         foreach ($item in $PSData.GetEnumerator()) {
             $key = $item.key

--- a/src/PSPublishHelper/private/Resolve-PSModuleDependency.ps1
+++ b/src/PSPublishHelper/private/Resolve-PSModuleDependency.ps1
@@ -4,13 +4,19 @@ function Resolve-PSModuleDependency {
     param (
         [Parameter(Mandatory, ValueFromPipeline)]
         [PSModuleInfo]
-        $Module
+        $Module,
+
+        [String[]]
+        $ExternalModuleDependencies
     )
     process {
         # The manifest contains the actual ModuleSpec used for Version requirements
         $ModuleData = $Module | Get-PSModuleManifestData
 
-        $ModuleData.RequiredModules | Resolve-PSModuleInfo
+        # A module in RequiredModules is not a dependency if it's listed in ExternalModuleDependencies
+        $ModuleData.RequiredModules | Resolve-PSModuleInfo | Where-Object {
+            $_.Name -notin $ExternalModuleDependencies
+        }
 
         $NestModuleInfo = $ModuleData.NestedModules | Resolve-PSModuleInfo
 


### PR DESCRIPTION
This just leaves ExternalModuleDependencies out of the dependencies that are documented in the nuspec.