### PR TITLE
Remove -recurse that is creating duplicate copied files in root

### DIFF
--- a/src/PSPublishHelper/private/Copy-PSModule.ps1
+++ b/src/PSPublishHelper/private/Copy-PSModule.ps1
@@ -25,7 +25,7 @@ function Copy-PSModule {
             Force = $true
         }
         $null = Microsoft.PowerShell.Management\New-Item @Params
-        Microsoft.PowerShell.Management\Get-ChildItem $Module.ModuleBase -recurse |
+        Microsoft.PowerShell.Management\Get-ChildItem $Module.ModuleBase |
             ForEach-Object {
                 if ($_.PSIsContainer) {
                     $Params = @{


### PR DESCRIPTION
Remove extra recurse that is causing an improper file copy when preparing compiled module folder.